### PR TITLE
implicit grant URL was returning an error, change to type=token

### DIFF
--- a/main.go
+++ b/main.go
@@ -84,7 +84,7 @@ func HomeHandler(c goauth.Config) func(rw http.ResponseWriter, req *http.Request
 			</li>
 		</ul>`,
 			c.AuthCodeURL("some-random-state-foobar")+"&nonce=some-random-nonce",
-			"http://localhost:3846/oauth2/auth?client_id=my-client&redirect_uri=http%3A%2F%2Flocalhost%3A3846%2Fcallback&response_type=token%20id_token&scope=fosite%20openid&state=some-random-state-foobar&nonce=some-random-nonce",
+			"http://localhost:3846/oauth2/auth?client_id=my-client&redirect_uri=http%3A%2F%2Flocalhost%3A3846%2Fcallback&response_type=token&scope=fosite%20openid&state=some-random-state-foobar&nonce=some-random-nonce",
 			c.AuthCodeURL("some-random-state-foobar")+"&nonce=some-random-nonce",
 			"/oauth2/auth?client_id=my-client&scope=fosite&response_type=123&redirect_uri=http://localhost:3846/callback",
 		)))


### PR DESCRIPTION
without this change, the following error URL is generated:

```
http://localhost:3846/callback#error=unsupported_response_type&error_description=The+authorization+server+does+not+support+obtaining+a+token+using+this+method&state=some-random-state-foobar
```