### PR TITLE
fix: Use request context

### DIFF
--- a/authorizationserver/oauth2_auth.go
+++ b/authorizationserver/oauth2_auth.go
@@ -4,13 +4,11 @@ import (
 	"fmt"
 	"log"
 	"net/http"
-
-	"github.com/ory/fosite"
 )
 
 func authEndpoint(rw http.ResponseWriter, req *http.Request) {
 	// This context will be passed to all methods.
-	ctx := fosite.NewContext()
+	ctx := req.Context()
 
 	// Let's create an AuthorizeRequest object!
 	// It will analyze the request and extract important information like scopes, response type and others.

--- a/authorizationserver/oauth2_introspect.go
+++ b/authorizationserver/oauth2_introspect.go
@@ -3,12 +3,10 @@ package authorizationserver
 import (
 	"log"
 	"net/http"
-
-	"github.com/ory/fosite"
 )
 
 func introspectionEndpoint(rw http.ResponseWriter, req *http.Request) {
-	ctx := fosite.NewContext()
+	ctx := req.Context()
 	mySessionData := newSession("")
 	ir, err := oauth2.NewIntrospectionRequest(ctx, req, mySessionData)
 	if err != nil {

--- a/authorizationserver/oauth2_revoke.go
+++ b/authorizationserver/oauth2_revoke.go
@@ -2,13 +2,11 @@ package authorizationserver
 
 import (
 	"net/http"
-
-	"github.com/ory/fosite"
 )
 
 func revokeEndpoint(rw http.ResponseWriter, req *http.Request) {
 	// This context will be passed to all methods.
-	ctx := fosite.NewContext()
+	ctx := req.Context()
 
 	// This will accept the token revocation request and validate various parameters.
 	err := oauth2.NewRevocationRequest(ctx, req)

--- a/authorizationserver/oauth2_token.go
+++ b/authorizationserver/oauth2_token.go
@@ -9,7 +9,7 @@ import (
 
 func tokenEndpoint(rw http.ResponseWriter, req *http.Request) {
 	// This context will be passed to all methods.
-	ctx := fosite.NewContext()
+	ctx := req.Context()
 
 	// Create an empty session object which will be passed to the request handlers
 	mySessionData := newSession("")


### PR DESCRIPTION
Request already has a context, no need to create a new unrelated context?