### PR TITLE
fix: removes use of deprecated type `oauth2.NoContext` in favour of `context.Background()`

### DIFF
--- a/oauth2client/handler_app_callback.go
+++ b/oauth2client/handler_app_callback.go
@@ -1,6 +1,7 @@
 package oauth2client
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -75,7 +76,7 @@ func CallbackHandler(c oauth2.Config) func(rw http.ResponseWriter, req *http.Req
 			req.URL.Query().Get("code"),
 		)))
 
-		token, err := c.Exchange(oauth2.NoContext, req.URL.Query().Get("code"))
+		token, err := c.Exchange(context.Background(), req.URL.Query().Get("code"))
 		if err != nil {
 			rw.Write([]byte(fmt.Sprintf(`<p>I tried to exchange the authorize code for an access token but it did not work but got error: %s</p>`, err.Error())))
 			return

--- a/oauth2client/handler_oauth2_client_flow.go
+++ b/oauth2client/handler_oauth2_client_flow.go
@@ -1,17 +1,17 @@
 package oauth2client
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 
-	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/clientcredentials"
 )
 
 func ClientEndpoint(c clientcredentials.Config) func(rw http.ResponseWriter, req *http.Request) {
 	return func(rw http.ResponseWriter, req *http.Request) {
 		rw.Write([]byte("<h1>Client Credentials Grant</h1>"))
-		token, err := c.Token(oauth2.NoContext)
+		token, err := c.Token(context.Background())
 		if err != nil {
 			rw.Write([]byte(fmt.Sprintf(`<p>I tried to get a token but received an error: %s</p>`, err.Error())))
 			return

--- a/oauth2client/handler_oauth2_owner_flow.go
+++ b/oauth2client/handler_oauth2_owner_flow.go
@@ -1,6 +1,7 @@
 package oauth2client
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 
@@ -29,7 +30,7 @@ func OwnerHandler(c oauth2.Config) func(rw http.ResponseWriter, req *http.Reques
 			return
 		}
 
-		token, err := c.PasswordCredentialsToken(oauth2.NoContext, req.Form.Get("username"), req.Form.Get("password"))
+		token, err := c.PasswordCredentialsToken(context.Background(), req.Form.Get("username"), req.Form.Get("password"))
 		if err != nil {
 			rw.Write([]byte(fmt.Sprintf(`<p>I tried to get a token but received an error: %s</p>`, err.Error())))
 			rw.Write([]byte(`<p><a href="/">Go back</a></p>`))


### PR DESCRIPTION
IDE fired up a deprecation warning, figured may as well clean it up ¯\_(ツ)_/¯

For reference:
```go
// NoContext is the default context you should supply if not using
// your own context.Context (see https://golang.org/x/net/context).
//
// Deprecated: Use context.Background() or context.TODO() instead.
var NoContext = context.TODO()
```