### PR TITLE
feat: adds support for Authorization Code (with OpenID) + PKCE.

### DIFF
--- a/main.go
+++ b/main.go
@@ -35,13 +35,12 @@ var appClientConf = clientcredentials.Config{
 }
 
 func main() {
-	// navigation
-	http.HandleFunc("/", HomeHandler(clientConf)) // show some links on the index
-
 	// ### oauth2 server ###
 	authorizationserver.RegisterHandlers() // the authorization server (fosite)
 
 	// ### oauth2 client ###
+	http.HandleFunc("/", oauth2client.HomeHandler(clientConf)) // show some links on the index
+
 	// the following handlers are oauth2 consumers
 	http.HandleFunc("/client", oauth2client.ClientEndpoint(appClientConf)) // complete a client credentials flow
 	http.HandleFunc("/owner", oauth2client.OwnerHandler(clientConf))       // complete a resource owner password credentials flow
@@ -58,36 +57,4 @@ func main() {
 	fmt.Println("Please open your webbrowser at http://localhost:" + port)
 	_ = exec.Command("open", "http://localhost:"+port).Run()
 	log.Fatal(http.ListenAndServe(":"+port, nil))
-}
-
-func HomeHandler(c goauth.Config) func(rw http.ResponseWriter, req *http.Request) {
-	return func(rw http.ResponseWriter, req *http.Request) {
-		rw.Write([]byte(fmt.Sprintf(`
-		<p>You can obtain an access token using various methods</p>
-		<ul>
-			<li>
-				<a href="%s">Authorize code grant (with OpenID Connect)</a>
-			</li>
-			<li>
-				<a href="%s">Implicit grant (with OpenID Connect)</a>
-			</li>
-			<li>
-				<a href="/client">Client credentials grant</a>
-			</li>
-			<li>
-				<a href="/owner">Resource owner password credentials grant</a>
-			</li>
-			<li>
-				<a href="%s">Refresh grant</a>. <small>You will first see the login screen which is required to obtain a valid refresh token.</small>
-			</li>
-			<li>
-				<a href="%s">Make an invalid request</a>
-			</li>
-		</ul>`,
-			c.AuthCodeURL("some-random-state-foobar")+"&nonce=some-random-nonce",
-			"http://localhost:3846/oauth2/auth?client_id=my-client&redirect_uri=http%3A%2F%2Flocalhost%3A3846%2Fcallback&response_type=token%20id_token&scope=fosite%20openid&state=some-random-state-foobar&nonce=some-random-nonce",
-			c.AuthCodeURL("some-random-state-foobar")+"&nonce=some-random-nonce",
-			"/oauth2/auth?client_id=my-client&scope=fosite&response_type=123&redirect_uri=http://localhost:3846/callback",
-		)))
-	}
 }

--- a/oauth2client/handler_index.go
+++ b/oauth2client/handler_index.go
@@ -1,0 +1,66 @@
+package oauth2client
+
+import (
+	"fmt"
+	"net/http"
+
+	goauth "golang.org/x/oauth2"
+)
+
+func HomeHandler(c goauth.Config) func(rw http.ResponseWriter, req *http.Request) {
+	return func(rw http.ResponseWriter, req *http.Request) {
+		if req.URL.Path != "/" {
+			// The "/" pattern matches everything, so we need to check that
+			// we're at the root here.
+			return
+		}
+
+		// rotate PKCE secrets
+		pkceCodeVerifier = generateCodeVerifier(64)
+		pkceCodeChallenge = generateCodeChallenge(pkceCodeVerifier)
+
+		rw.Write([]byte(fmt.Sprintf(`
+		<p>You can obtain an access token using various methods</p>
+		<ul>
+			<li>
+				<a href="%s">Authorize code grant (with OpenID Connect)</a>
+			</li>
+			<li>
+				<a href="%s" onclick="setPKCE()">Authorize code grant (with OpenID Connect) with PKCE</a>
+			</li>
+			<li>
+				<a href="%s">Implicit grant (with OpenID Connect)</a>
+			</li>
+			<li>
+				<a href="/client">Client credentials grant</a>
+			</li>
+			<li>
+				<a href="/owner">Resource owner password credentials grant</a>
+			</li>
+			<li>
+				<a href="%s">Refresh grant</a>. <small>You will first see the login screen which is required to obtain a valid refresh token.</small>
+			</li>
+			<li>
+				<a href="%s">Make an invalid request</a>
+			</li>
+		</ul>
+
+		<script type="text/javascript">
+			function setPKCE() {
+				// push in a cookie that the user-agent can check to see if last request was a PKCE request.
+				document.cookie = '`+cookiePKCE+`=true';
+			}
+			
+			(function(){
+				// clear existing isPKCE cookie if returning to the home page.
+				document.cookie = '`+cookiePKCE+`=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;';
+			})();
+		</script>`,
+			c.AuthCodeURL("some-random-state-foobar")+"&nonce=some-random-nonce",
+			c.AuthCodeURL("some-random-state-foobar")+"&nonce=some-random-nonce&code_challenge="+pkceCodeChallenge+"&code_challenge_method=S256",
+			"http://localhost:3846/oauth2/auth?client_id=my-client&redirect_uri=http%3A%2F%2Flocalhost%3A3846%2Fcallback&response_type=token%20id_token&scope=fosite%20openid&state=some-random-state-foobar&nonce=some-random-nonce",
+			c.AuthCodeURL("some-random-state-foobar")+"&nonce=some-random-nonce",
+			"/oauth2/auth?client_id=my-client&scope=fosite&response_type=123&redirect_uri=http://localhost:3846/callback",
+		)))
+	}
+}

--- a/oauth2client/oauth2client.go
+++ b/oauth2client/oauth2client.go
@@ -1,0 +1,91 @@
+package oauth2client
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"math/big"
+	"net/http"
+	"time"
+)
+
+// The following provides the setup required for the client to perform the "Authorization Code" flow with PKCE in order
+// to obtain an access token for public/untrusted clients.
+
+const cookiePKCE = "isPKCE"
+
+var (
+	// pkceCodeVerifier stores the generated random value which the client will on-send to the auth server with the received
+	// authorization code. This way the oauth server can verify that the base64URLEncoded(sha265(codeVerifier)) matches
+	// the stored code challenge, which was initially sent through with the code+PKCE authorization request to ensure
+	// that this is the original user-agent who requested the access token.
+	pkceCodeVerifier string
+
+	// pkceCodeChallenge stores the base64(sha256(codeVerifier)) which is sent from the
+	// client to the auth server as required for PKCE.
+	pkceCodeChallenge string
+)
+
+// The following sets up the requirements for generating a standards compliant PKCE code verifier.
+const codeVerifierLenMin = 43
+const codeVerifierLenMax = 128
+const codeVerifierAllowedLetters = "abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ._~"
+
+// generateCodeVerifier provides an easy way to generate an n-length randomised
+// code verifier.
+func generateCodeVerifier(n int) string {
+	// Enforce standards compliance...
+	if n < codeVerifierLenMin {
+		n = codeVerifierLenMin
+	}
+	if n > codeVerifierLenMax {
+		n = codeVerifierLenMax
+	}
+
+	// Randomly choose some allowed characters...
+	b := make([]byte, n)
+	for i := range b {
+		// ensure we use non-deterministic random ints.
+		j, _ := rand.Int(rand.Reader, big.NewInt(int64(len(codeVerifierAllowedLetters))))
+		b[i] = codeVerifierAllowedLetters[j.Int64()]
+	}
+
+	return string(b)
+}
+
+// generateCodeChallenge returns a standards compliant PKCE S(HA)256 code
+// challenge.
+func generateCodeChallenge(codeVerifier string) string {
+	// Create a sha-265 hash from the code verifier...
+	s256 := sha256.New()
+	s256.Write([]byte(codeVerifier))
+
+	// Then base64 encode the hash sum to create a code challenge...
+	return base64.RawURLEncoding.EncodeToString(s256.Sum(nil))
+}
+
+// isPKCE detects whether a PKCE auth request was made.
+func isPKCE(r *http.Request) bool {
+	cookie, err := r.Cookie(cookiePKCE)
+	if err != nil {
+		return false
+	}
+
+	return cookie.Value == "true"
+}
+
+// resetPKCE cleans up PKCE details and returns the code verifier.
+func resetPKCE(w http.ResponseWriter) (codeVerifier string) {
+	// remove cookie that informs the client the callback request was a PKCE
+	// request.
+	http.SetCookie(w, &http.Cookie{
+		Name:    cookiePKCE,
+		Path:    "/",
+		Expires: time.Unix(0, 0),
+	})
+
+	codeVerifier = pkceCodeVerifier
+	pkceCodeVerifier = ""
+
+	return codeVerifier
+}


### PR DESCRIPTION
This PR moves the index/home page into the `oauth2client` package so that the PKCE `code_verifier` + `code_challenge` requirements were scoped into the one package, otherwise it got a bit messy injecting the `code_verifier`+`code_challenge` between `main`+`oauth2client`.

Overview:
- `code_verifier` + `code_challenge` is generated when loading the index/home page.
- The generated `code_challenge` is pushed into the "`Authorize code grant (with OpenID Connect) with PKCE`" link
- A `isPKCE` cookie gets set on clicking the "`Authorize code grant (with OpenID Connect) with PKCE`" link.
- When hitting the callback route, the client detects if the `isPKCE` cookie is set and if so will send `code_verifier` when requesting the access token.
- Loading the callback page will always remove the `isPKCE` cookie.
- Loading the index/home page will always remove the `isPKCE` cookie.
