### PR TITLE
feat: Updating token endpoint scope granting

### DIFF
--- a/authorizationserver/oauth2_token.go
+++ b/authorizationserver/oauth2_token.go
@@ -3,8 +3,6 @@ package authorizationserver
 import (
 	"log"
 	"net/http"
-
-	"github.com/ory/fosite"
 )
 
 func tokenEndpoint(rw http.ResponseWriter, req *http.Request) {
@@ -27,12 +25,12 @@ func tokenEndpoint(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	// If this is a client_credentials grant, grant all scopes the client is allowed to perform.
-	if accessRequest.GetGrantTypes().Exact("client_credentials") {
+	// If this is a client_credentials grant, grant all requested scopes
+	// NewAccessRequest validated that all requested scopes the client is allowed to perform
+	// based on configured scope matching strategy.
+	if accessRequest.GetGrantTypes().ExactOne("client_credentials") {
 		for _, scope := range accessRequest.GetRequestedScopes() {
-			if fosite.HierarchicScopeStrategy(accessRequest.GetClient().GetScopes(), scope) {
-				accessRequest.GrantScope(scope)
-			}
+			accessRequest.GrantScope(scope)
 		}
 	}
 


### PR DESCRIPTION
I think this is better example. First, `Exact` is deprecated.

Second, it is not necessary to check scopes once again, because all requested scopes are already checked.