### PR TITLE
ci: Bump go version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: go
 go_import_path: github.com/ory/fosite-example
 
 go:
-  - 1.12
+  - 1.13
 
 env:
   - GO111MODULE=on


### PR DESCRIPTION
Readme says this works for Go 1.13 or newer. So CI should run that, no?